### PR TITLE
Remove the Nix pin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,6 @@ jobs:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@v12
         with:
-          # Use Nix 2.19.3 due to https://github.com/NixOS/nix/issues/10022
-          nix-installer-tag: v0.16.1
           diagnostic-endpoint: ""
       - uses: DeterminateSystems/magic-nix-cache-action@v7
         with:
@@ -25,6 +23,7 @@ jobs:
             jq -c ".packages.\"x86_64-linux\" | keys" >> "$GITHUB_OUTPUT"
     outputs:  
       packages: ${{steps.packages.outputs.packages}}
+
   build:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -15,8 +15,6 @@ jobs:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@v12
         with:
-          # Use Nix 2.19.3 due to https://github.com/NixOS/nix/issues/10022
-          nix-installer-tag: v0.16.1
           diagnostic-endpoint: ""
       - name: Nix cache
         uses: actions/cache@v4


### PR DESCRIPTION
It looks like https://github.com/NixOS/nix/issues/10022 is fixed in newer versions. I ran the CI flow, and it looks like all the builds are continuing to work as it is on your current main.